### PR TITLE
Changing `two` to `several`

### DIFF
--- a/components/Wallet/Options.vue
+++ b/components/Wallet/Options.vue
@@ -2,7 +2,7 @@
   <div class="c-wallet-options" id="setup">
     <div class="container">
       <h2 class="c-wallet-options__title">
-        There are currently two options to get a free PKT Wallet
+        There are currently several options to get a free PKT Wallet
       </h2>
       <div class="c-wallet-options__list">
         <div class="c-wallet-options__item">


### PR DESCRIPTION
Based on the list, it seems there are now several options, not just two. Using `several` instead of a specific number to keep it generic enough if more get added (or, removed) in the future.