### PR TITLE
fix(Header.vue): prevent 404 when clicking navigation links on auxiliary pages

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -186,7 +186,7 @@ export default {
         // },
         {
           name: this.$t("header.mine"),
-          route_link: "mine",
+          route_link: "/mine",
         },
         {
           name: this.$t("home.roadmap_link"),
@@ -194,11 +194,11 @@ export default {
         },
         {
           name: "Wallet",
-          route_link: "wallet",
+          route_link: "/wallet",
         },
         {
           name: "Community",
-          route_link: "community",
+          route_link: "/community",
         },
         {
           name: "PKT",


### PR DESCRIPTION
Modify navigation routing links to include the root path to prevent top level links from being routed improperly.

### Steps to reproduce this bug on production:

1. Visit an auxiliary link: i.e. https://pkt.cash/about
2. Refresh the page such that it adds a trailing / : i.e. https://pkt.cash/about/
3. Click the Wallet Link
4. 404 on the Wallet Link

### Where this bug appears on production:
The non-exhaustive list of browsers experiencing this bug:

1. Safari
2. Firefox
3. Brave
4. Chromium
5. Chrome